### PR TITLE
4 8 work with size

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:places/mocks.dart';
 import 'package:places/ui/screen/Sight_details.dart';
+import 'package:places/ui/screen/sight_list_screen.dart';
 
 void main() {
   runApp(const App());
@@ -18,7 +19,7 @@ class App extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: SightDetails(sightMocks[mockNumber]),
+      home: SightListScreen(),
     );
   }
 }

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -8,67 +8,75 @@ class SightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(children: [
-      Stack(
-        children: [
-          Container(
-            // Виджет под фотографию
-            height: 96,
-            width: double.infinity,
-            decoration: BoxDecoration(
-                borderRadius:
-                    BorderRadius.only(topLeft: Radius.circular(cornerRadius), topRight: Radius.circular(cornerRadius)),
-                color: Colors.amber),
-          ),
-          Align(
-            alignment: Alignment.topLeft,
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Text(
-                sight.type,
-                style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: Colors.white),
+    return AspectRatio(
+      aspectRatio: 3/2,
+      child: Column(children: [
+        Expanded(
+          flex: 3,
+          child: Stack(
+            children: [
+              Container(
+                // Виджет под фотографию
+                width: double.infinity,
+                decoration: BoxDecoration(
+                    borderRadius:
+                        BorderRadius.only(topLeft: Radius.circular(cornerRadius), topRight: Radius.circular(cornerRadius)),
+                    color: Colors.amber),
               ),
-            ),
-          ),
-          Align(
-              alignment: Alignment.topRight,
-              child: Padding(
-                padding: EdgeInsets.only(right: 18, top: 12),
-                child: Icon(
-                  Icons.favorite_border_outlined,
-                  color: Colors.white,
-                  size: 26,
+              Align(
+                alignment: Alignment.topLeft,
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Text(
+                    sight.type,
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: Colors.white),
+                  ),
                 ),
-              )),
-        ],
-      ),
-      Container(
-        width: double.infinity,
-        padding: EdgeInsets.all(16),
-        decoration: BoxDecoration(
-            color: Color(0xffF5F5F5),
-            borderRadius: BorderRadius.only(
-                bottomLeft: Radius.circular(cornerRadius), bottomRight: Radius.circular(cornerRadius))),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            ConstrainedBox(
-              constraints: BoxConstraints(maxWidth: 200),
-              child: Text(
-                sight.name,
-                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
               ),
-            ),
-            Container(
-              margin: EdgeInsets.only(top: 2),
-              child: Text(
-                'краткое описание',
-                style: TextStyle(fontSize: 14, fontWeight: FontWeight.w400, color: Color(0xff7C7E92)),
-              ),
-            )
-          ],
+              Align(
+                  alignment: Alignment.topRight,
+                  child: Padding(
+                    padding: EdgeInsets.only(right: 18, top: 12),
+                    child: Icon(
+                      Icons.favorite_border_outlined,
+                      color: Colors.white,
+                      size: 26,
+                    ),
+                  )),
+            ],
+          ),
         ),
-      )
-    ]);
+        Expanded(
+          flex: 2,
+          child: Container(
+            width: double.infinity,
+            padding: EdgeInsets.all(16),
+            decoration: BoxDecoration(
+                color: Color(0xffF5F5F5),
+                borderRadius: BorderRadius.only(
+                    bottomLeft: Radius.circular(cornerRadius), bottomRight: Radius.circular(cornerRadius))),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ConstrainedBox(
+                  constraints: BoxConstraints(maxWidth: 200),
+                  child: Text(
+                    sight.name,
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                  ),
+                ),
+                Container(
+                  margin: EdgeInsets.only(top: 2),
+                  child: Text(
+                    'краткое описание',
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w400, color: Color(0xff7C7E92)),
+                  ),
+                )
+              ],
+            ),
+          ),
+        )
+      ]),
+    );
   }
 }

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -3,12 +3,11 @@ import 'package:places/domain/sight.dart';
 
 class SightCard extends StatelessWidget {
   final Sight sight;
+  final double cornerRadius = 12;
   const SightCard(this.sight);
 
   @override
   Widget build(BuildContext context) {
-    double cornerRadius = 12;
-    
     return Column(children: [
       Stack(
         children: [
@@ -53,7 +52,8 @@ class SightCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Container(
+            ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: 200),
               child: Text(
                 sight.name,
                 style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -4,12 +4,14 @@ import 'package:places/domain/sight.dart';
 class SightCard extends StatelessWidget {
   final Sight sight;
   final double cornerRadius = 12;
+  final double cardAspectRatio = 3/2;
+  
   const SightCard(this.sight);
 
   @override
   Widget build(BuildContext context) {
     return AspectRatio(
-      aspectRatio: 3/2,
+      aspectRatio: cardAspectRatio,
       child: Column(children: [
         Expanded(
           flex: 3,

--- a/lib/ui/screen/sight_list_screen.dart
+++ b/lib/ui/screen/sight_list_screen.dart
@@ -21,14 +21,26 @@ class _SightListScreenState extends State<SightListScreen> {
         backgroundColor: Colors.transparent,
         shadowColor: Colors.transparent,
         toolbarHeight: toolbarHeight,
-        title: Text('Список \nинтеренсных мест', style: TextStyle(fontSize: appBarTextSize, fontWeight: FontWeight.w700, color: Colors.black))
+        bottom: PreferredSize(
+          preferredSize: Size.fromHeight(0),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: ConstrainedBox(
+              constraints: BoxConstraints.tightFor(width: double.infinity),
+              child: Text('Список \nинтересных мест',
+                  style: TextStyle(fontSize: appBarTextSize, fontWeight: FontWeight.w700, color: Colors.black)),
+            ),
+          ),
+        ),
       ),
       body: SingleChildScrollView(
         child: Column(
-          children: List.generate(sightMocks.length, (index) => Padding(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
-            child: SightCard(sightMocks[index]),
-          )),
+          children: List.generate(
+              sightMocks.length,
+              (index) => Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                    child: SightCard(sightMocks[index]),
+                  )),
         ),
       ),
     );


### PR DESCRIPTION
- В виджете SightCard используйте ConstrainedBox, чтобы ограничить размер текста  по ширине до половины размера карточки. Посмотрите на результат. Почему размер виджета Text поменялся? После выполнения,  отрегулируйте размер текста согласно дизайну.

**Виджет Text по ширине занимает максимально возможные размеры родителя, соответственно если тексту нужно больше ширины, то он переносит слова на следующую строку.** 

- Добавьте отступ между между фотографиями и описанием с помощью SizedBox
**Done**

- AspectRatio используйте, чтобы привести виджеты SightCard в соотношение 3/2
**Done**

- Переверстать AppBar через наследника PreferredSizeWidget.
**Done**

![Screenshot_1637674905](https://user-images.githubusercontent.com/21194287/143034960-a84c3d77-05b3-401d-b0b0-a192e7826552.png)

Результаты dart_code_metrics

![image](https://user-images.githubusercontent.com/21194287/143036180-5540b902-7f33-4abd-a87c-e901ccfc0647.png)

